### PR TITLE
Add Optional `private_repo_password` Input to Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
   flags:
     description: "Additional flags to pass to `go test <packages> -list ."
     required: false
+  private_repo_password:
+    description: 'Password for the private repository'
+    required: false
   junit-summary:
     description: "Path to a JUnit summary XML file that can help optimize test slicing. See the JUnit example in the README."
     required: false

--- a/src/action.ts
+++ b/src/action.ts
@@ -5,6 +5,7 @@
 
 import * as core from "@actions/core";
 import * as io from "@actions/io";
+import * as fs from 'fs';
 
 import {GoTestLister, ListerOptions} from "./go-test-lister";
 
@@ -54,6 +55,10 @@ export function configure(
 (async () => {
   try {
     const lister = configure(await io.which("go"));
+    const privateRepoPassword = core.getInput('private_repo_password');
+    if (privateRepoPassword) {
+      fs.writeFileSync(process.env.HOME + '/.netrc', `machine github.com login git password ${privateRepoPassword}`);
+    }    
     await core.group("Generate go test Slice", async () => {
       core.setOutput("run", await lister.outputTestListForRunArg());
     });


### PR DESCRIPTION
This pull request introduces an optional input to the GitHub Action, `private_repo_password`. This input allows users to provide a password for accessing a private repository if necessary.

Changes include:
* An update to `action.yml` to define the new `private_repo_password` input.
* Modifications to `action.ts` to retrieve the `private_repo_password` input and, if provided, write it to the `~/.netrc` file.

This change enhances the action's flexibility by allowing it to interact with private repositories, expanding its use cases.