### PR TITLE
Add working-directory Input and Update Package Version to 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ List tests using go tooling by executing `go test ./... -list .` in the `GITHUB_
 
 Use the `packages` input to customize the packages string, and the `list` input to customize the list pattern. Pass additional test flags using `flags` (See action.yml for details)
 
+Use the `working-directory` input to change the directory from which
+tests are listed.
+
 ### Better Test Balancing using `junit-summary`
 
 Normally, test splitting is achieved by balancing the quantity of tests across the _total_ slices.

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ inputs:
   junit-summary:
     description: "Path to a JUnit summary XML file that can help optimize test slicing. See the JUnit example in the README."
     required: false
+  working-directory:
+    description: "The working directory in which to list the tests. Defaults to the GitHub workspace."
+    required: false
 outputs:
   run:
     description: "A slice of tests, suitable to pass into the -run argument of go test"

--- a/dist/index.js
+++ b/dist/index.js
@@ -5745,7 +5745,7 @@ function configure(whichGo, env) {
         // JUnit option
         junitSummary: core.getInput("junit-summary"),
         // Env
-        workingDirectory: process.env.GITHUB_WORKSPACE,
+        workingDirectory: core.getInput("working-directory") || process.env.GITHUB_WORKSPACE,
         env,
     };
     // Input validation

--- a/dist/index.js
+++ b/dist/index.js
@@ -5489,6 +5489,8 @@ __nccwpck_require__.d(__webpack_exports__, {
 var core = __nccwpck_require__(2186);
 // EXTERNAL MODULE: ./node_modules/@actions/io/lib/io.js
 var io = __nccwpck_require__(7436);
+// EXTERNAL MODULE: external "path"
+var external_path_ = __nccwpck_require__(1017);
 // EXTERNAL MODULE: external "child_process"
 var external_child_process_ = __nccwpck_require__(2081);
 ;// CONCATENATED MODULE: ./src/logger.ts
@@ -5731,6 +5733,7 @@ var action_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _a
 
 
 
+
 function configure(whichGo, env) {
     let opts = {
         // The go binary-- in GHA, this should be the result of await io.which("go")
@@ -5745,7 +5748,7 @@ function configure(whichGo, env) {
         // JUnit option
         junitSummary: core.getInput("junit-summary"),
         // Env
-        workingDirectory: core.getInput("working-directory") || process.env.GITHUB_WORKSPACE,
+        workingDirectory: external_path_.join(process.env.GITHUB_WORKSPACE, core.getInput("working-directory")),
         env,
     };
     // Input validation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "test-split-go",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "test-split-go",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.2.1",
+        "@types/node": "^20.12.8",
         "@vercel/ncc": "^0.34.0",
         "husky": "^8.0.2",
         "jest": "^29.2.2",
@@ -1163,10 +1164,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
-      "dev": true
+      "version": "20.12.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.8.tgz",
+      "integrity": "sha512-NU0rJLJnshZWdE/097cdCBbyW1h4hEg0xpovcoAQYHl8dnEyp/NAOiE45pvc+Bd1Dt+2r94v2eGFpQJ4R7g+2w==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.7.1",
@@ -3530,6 +3534,12 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
@@ -4604,10 +4614,13 @@
       }
     },
     "@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
-      "dev": true
+      "version": "20.12.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.8.tgz",
+      "integrity": "sha512-NU0rJLJnshZWdE/097cdCBbyW1h4hEg0xpovcoAQYHl8dnEyp/NAOiE45pvc+Bd1Dt+2r94v2eGFpQJ4R7g+2w==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/prettier": {
       "version": "2.7.1",
@@ -6332,6 +6345,12 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
       "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.2.1",
+    "@types/node": "^20.12.8",
     "@vercel/ncc": "^0.34.0",
     "husky": "^8.0.2",
     "jest": "^29.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-split-go",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": "true",
   "description": "Github action that lists a subset of tests suitable for passing into go test -run",
   "main": "dist/index.js",

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -28,6 +28,9 @@ describe("action output", () => {
 
     outputSpy = jest.spyOn(core, "setOutput");
     outputSpy.mockImplementation((name, value) => (outputs[name] = value));
+
+    process.env.GITHUB_WORKSPACE = process.cwd() + "/test-fixtures";
+    inputs["working-directory"] = "example-app";
   });
 
   afterEach(() => {

--- a/src/action.ts
+++ b/src/action.ts
@@ -30,7 +30,10 @@ export function configure(
     junitSummary: core.getInput("junit-summary"),
 
     // Env
-    workingDirectory: path.join(process.env.GITHUB_WORKSPACE, core.getInput("working-directory")),
+    workingDirectory: path.join(
+      process.env.GITHUB_WORKSPACE,
+      core.getInput("working-directory")
+    ),
     env,
   };
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -29,7 +29,8 @@ export function configure(
     junitSummary: core.getInput("junit-summary"),
 
     // Env
-    workingDirectory: process.env.GITHUB_WORKSPACE,
+    workingDirectory:
+      core.getInput("working-directory") || process.env.GITHUB_WORKSPACE,
     env,
   };
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -5,6 +5,7 @@
 
 import * as core from "@actions/core";
 import * as io from "@actions/io";
+import * as path from "path";
 
 import {GoTestLister, ListerOptions} from "./go-test-lister";
 
@@ -29,8 +30,7 @@ export function configure(
     junitSummary: core.getInput("junit-summary"),
 
     // Env
-    workingDirectory:
-      core.getInput("working-directory") || process.env.GITHUB_WORKSPACE,
+    workingDirectory: path.join(process.env.GITHUB_WORKSPACE, core.getInput("working-directory")),
     env,
   };
 


### PR DESCRIPTION
This pull request adds a `working-directory` input to enable support for testing Go modules in repository subdirectories. It also updates the package version to 1.0.2 as it did not get updated with that release.